### PR TITLE
fix: resolve launch configuration issue that only worked from specific directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,3 +11,5 @@
 LICENSE @dklee98
 Makefile @dklee98
 .github/PULL_REQUEST_TEMPLATE.md @dklee98 @anahrendra
+pipelines/ros2/launch/trg_planner_wMap.py @lrrghdrh
+pipelines/ros2/CMakeLists.txt @lrrghdrh

--- a/pipelines/ros2/CMakeLists.txt
+++ b/pipelines/ros2/CMakeLists.txt
@@ -48,6 +48,7 @@ install(TARGETS
 install(DIRECTORY
     launch
     config
+    rviz
     DESTINATION share/${PROJECT_NAME}
 )
 

--- a/pipelines/ros2/launch/trg_planner_wMap.py
+++ b/pipelines/ros2/launch/trg_planner_wMap.py
@@ -1,5 +1,3 @@
-import os
-
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
@@ -26,7 +24,7 @@ def generate_launch_description():
         package_share_directory, '/config/', 'ros2_params.yaml'
     ]
     rviz_config_file = [
-        os.path.join(os.getcwd(), 'src/TRG-planner/pipelines/ros2/rviz/'),
+        package_share_directory, '/rviz/',
         LaunchConfiguration('map'), '.rviz'
     ]
 


### PR DESCRIPTION
# Description
This PR fixes the issue where ROS 2 launch files, RViz configurations, and other resources could only be loaded correctly when run from a specific directory.
The change introduces an `install(DIRECTORY ...)` rule in CMake to install rviz directories to the correct location under `share/${PROJECT_NAME}`.
Additionally, all paths in launch files are now resolved relative to get_package_share_directory, allowing the launch process to work regardless of the current working directory.

This change improves portability and robustness of the ROS 2 package, especially when used in installed or deployed environments.

Closes #(issue)

## Type of change
- Bug fix

## Checklist
- [x] I have run `pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] The changes require some tests and have been tested
- [x] I have added my name into `CODEOWNERS` for the corresponding changes
